### PR TITLE
Use wider grid layout below desktop breakpoint

### DIFF
--- a/app/layouts/check-answers.njk
+++ b/app/layouts/check-answers.njk
@@ -6,7 +6,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-three-quarters-from-desktop">
       {{ macro.heading(title, caption) }}
 
       {% block checkAnswers %}

--- a/app/layouts/question.njk
+++ b/app/layouts/question.njk
@@ -5,7 +5,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ govukErrorSummary({
         titleText: "There is a problem",
         errorList: errorList(errors)

--- a/app/views/account/check-your-email.njk
+++ b/app/views/account/check-your-email.njk
@@ -4,7 +4,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title) }}
 
       <p><a class="govuk-link--no-underline govuk-link--text-colour" href="/email/reset-password">We’ve sent a link to reset your password to <strong>{{ data.account.email or "name@example.com" }}</strong>.</a></p>

--- a/app/views/account/create-account.njk
+++ b/app/views/account/create-account.njk
@@ -5,7 +5,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title) }}
 
       <p>You have been invited to create an account with the email address <strong>jane.doe@example.gov.uk</strong>.</p>

--- a/app/views/account/index.njk
+++ b/app/views/account/index.njk
@@ -7,7 +7,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title) }}
 
       <h2 class="govuk-heading-m">Personal details</h2>

--- a/app/views/account/password.njk
+++ b/app/views/account/password.njk
@@ -6,7 +6,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title) }}
 
       {{ govukInput({

--- a/app/views/account/personal-details.njk
+++ b/app/views/account/personal-details.njk
@@ -6,7 +6,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title) }}
 
       {{ govukInput(decorate({

--- a/app/views/account/request-password-reset.njk
+++ b/app/views/account/request-password-reset.njk
@@ -6,7 +6,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title) }}
 
       <p>Enter the email address you used to create your account.</p>

--- a/app/views/account/reset-password.njk
+++ b/app/views/account/reset-password.njk
@@ -4,7 +4,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktops">
       {{ macro.heading(title) }}
 
       {{ govukInput({

--- a/app/views/account/sign-in.njk
+++ b/app/views/account/sign-in.njk
@@ -4,7 +4,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ govukNotificationBanner({
         text: "Your password has been reset. Sign in with your new password to continue.",
         type: "success"

--- a/app/views/demo-accounts.njk
+++ b/app/views/demo-accounts.njk
@@ -5,7 +5,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title) }}
 
       <h2 class="govuk-heading-m">DLUHC and support providers</h2>

--- a/app/views/logs/about-this-log/cannot-use-this-service.njk
+++ b/app/views/logs/about-this-log/cannot-use-this-service.njk
@@ -6,7 +6,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title) }}
 
       <p>We cannot accept data about a tenant or buyer unless they’ve seen the DLUHC privacy notice.</p>

--- a/app/views/logs/log.njk
+++ b/app/views/logs/log.njk
@@ -15,7 +15,7 @@
 
 {% block content %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       <h1 class="govuk-heading-xl govuk-!-width-two-thirds">{{ title }}</h1>
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">This log is incomplete</h2>
       <p class="govuk-body govuk-!-margin-bottom-7">

--- a/app/views/organisations/deactivate.njk
+++ b/app/views/organisations/deactivate.njk
@@ -5,7 +5,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title, organisation.name) }}
 
       {{ govukButton({

--- a/app/views/organisations/organisation.njk
+++ b/app/views/organisations/organisation.njk
@@ -30,7 +30,7 @@
   }) }}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {% if organisation.deactivated %}
         <p class="govuk-button-group">
           <span class="app-!-colour-muted govuk-!-margin-right-2">This organisation has been deactivated.</span>

--- a/app/views/organisations/reactivate.njk
+++ b/app/views/organisations/reactivate.njk
@@ -5,7 +5,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title, organisation.name) }}
 
       {{ govukButton({

--- a/app/views/users/deactivate.njk
+++ b/app/views/users/deactivate.njk
@@ -5,7 +5,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title, user.name) }}
 
       <p>Deactivating this user will mean they can no longer access this service to submit CORE data.</p>

--- a/app/views/users/delete.njk
+++ b/app/views/users/delete.njk
@@ -5,7 +5,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title, user.name) }}
 
       <p>Deleting this user will mean they can no longer access this service to submit CORE data.</p>

--- a/app/views/users/organisation.njk
+++ b/app/views/users/organisation.njk
@@ -15,7 +15,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ govukRadios(decorate({
         fieldset: {
           legend: {

--- a/app/views/users/personal-details.njk
+++ b/app/views/users/personal-details.njk
@@ -18,7 +18,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title, caption) }}
 
       {{ govukInput(decorate({

--- a/app/views/users/reactivate.njk
+++ b/app/views/users/reactivate.njk
@@ -5,7 +5,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {{ macro.heading(title, user.name) }}
 
       {{ govukButton({

--- a/app/views/users/role.njk
+++ b/app/views/users/role.njk
@@ -15,7 +15,7 @@
 
 {% block form %}
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {% set adminPermissionsHintHtml %}
         <ul class="govuk-list govuk-list--bullet govuk-hint">
           <li>Manages all logs</li>

--- a/app/views/users/user.njk
+++ b/app/views/users/user.njk
@@ -33,7 +33,7 @@
   {{ macro.heading(title) }}
 
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
       {% if user.deactivated %}
         <p class="govuk-button-group">
           <span class="app-!-colour-muted govuk-!-margin-right-2">This user has been deactivated.</span>


### PR DESCRIPTION
Most of the pages on our service have a two-thirds/one-third layout, yet without any content in the right-hand column.

Using the `govuk-grid-column-two-thirds` means that below the desktop breakpoint, the lefthand column is still forced to be 66% wide, which can get really narrow on devices with smaller screens. This is especially problematic on check your answers pages.

Therefore, on pages without a sidebar, instead of `govuk-grid-column-two-thirds` we should use `govuk-grid-column-two-thirds-from-desktop`. This means the two-thirds layout constraint only appears on ‘desktop’ screens.

Additionally, on check your answer pages, we should use `govuk-grid-column-three-quaters-from-desktop`, making the column just a little bit wider on these pages to provide space for key labels in summary lists.

## Before

<img height="480" src="https://user-images.githubusercontent.com/813383/142026120-10b91380-3d52-44b2-b503-368c58de0997.png" alt="govuk-grid-column-two-thirds (tablet)"> <img height="480" src="https://user-images.githubusercontent.com/813383/142026103-9e26314b-2a61-4a94-9458-9a2078c33200.png" alt="govuk-grid-column-two-thirds (desktop)">

## After

<img height="480" src="https://user-images.githubusercontent.com/813383/142026206-992e03a5-b5ab-4582-b2f0-3c8bf41d22e7.png" alt="govuk-grid-column-three-quarters-from-desktop (tablet)"> <img height="480" src="https://user-images.githubusercontent.com/813383/142026189-fa080158-6f7b-48a8-b2f4-4137bd3dad2a.png" alt="govuk-grid-column-three-quarters-from-desktop (desktop)">

