### PR TITLE
CLDC-731 Allow users to bypass tasklist and go to next incomplete section

### DIFF
--- a/app/data/sections.js
+++ b/app/data/sections.js
@@ -1,4 +1,4 @@
-export default (log) => {
+export function sections (log) {
   const logPath = `/logs/${log.id}`
 
   const getPaths = (sectionId, paths) => {

--- a/app/layouts/check-answers.njk
+++ b/app/layouts/check-answers.njk
@@ -19,7 +19,13 @@
       }, ["logs", log.id, section.id, "completed"])) if log }}
 
       {{ govukButton({
-        text: "Save and continue"
+        text: "Return to log"
+      }) }}
+
+      {{ govukButton({
+        classes: "govuk-button--secondary",
+        text: "Go to next incomplete section",
+        href: logPath + "/" + nextSection(log.id).id
       }) }}
     </div>
   </div>

--- a/app/routes/logs.js
+++ b/app/routes/logs.js
@@ -1,7 +1,7 @@
 import { validationResult } from 'express-validator'
 import { wizard } from 'govuk-prototype-rig'
 
-import sections from '../data/sections.js'
+import { sections } from '../data/sections.js'
 import * as utils from '../utils.js'
 import { validations } from '../validations.js'
 

--- a/app/views/logs/log.njk
+++ b/app/views/logs/log.njk
@@ -20,7 +20,7 @@
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">This log is incomplete</h2>
       <p class="govuk-body govuk-!-margin-bottom-7">
         You have completed 0 of {{ data.sections | length }} sections.<br>
-        Skip to next incomplete section: <a href="#item-{{ nextSection(log.id).id }}">{{ nextSection(log.id).text }}</a>
+        Skip to next incomplete section: <a href="#{{ nextSection(log.id).id }}">{{ nextSection(log.id).title }}</a>
       </p>
 
       {{ rigTaskList({


### PR DESCRIPTION
* Updates `nextSection` to be dynamic, gets next section that has not been marked as completed, and for which we have built into the prototype
* Adds a secondary button to check your answer pages allowing you to skip to the next incomplete section:
  
  <img width="460" alt="Screenshot 2021-12-01 at 13 26 30" src="https://user-images.githubusercontent.com/813383/144242501-3c220b89-0be4-4ac8-bcb6-766ed83f4b9d.png">
