### PR TITLE
CLDC-705 Use breadcrumbs to navigate logs

### DIFF
--- a/app/layouts/check-answers.njk
+++ b/app/layouts/check-answers.njk
@@ -1,13 +1,26 @@
 {% extends "layouts/form.njk" %}
 
 {% set title = title or "Check your answers" %}
-{% set backLink = 'javascript:history.go(-1);' %}
 {% set formAction = logPath %}
+
+{% block pageNavigation %}
+  {{ govukBreadcrumbs({
+    items: [{
+      href: "/logs",
+      text: "Case logs"
+    }, {
+      href: "/logs/" + log.id,
+      text: "Log " + log.id
+    }, {
+      text: caption
+    }]
+  }) }}
+{% endblock %}
 
 {% block form %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-three-quarters-from-desktop">
-      {{ macro.heading(title, caption) }}
+      {{ macro.heading(title) }}
 
       {% block checkAnswers %}
       {% endblock %}

--- a/app/layouts/question.njk
+++ b/app/layouts/question.njk
@@ -1,7 +1,20 @@
 {% extends "layouts/form.njk" %}
 
-{% set backLink = backLink or "javascript:history.go(-1);" %}
 {% set formAction = formAction or paths.current %}
+
+{% block pageNavigation %}
+  {{ govukBreadcrumbs({
+    items: [{
+      href: "/logs",
+      text: "Case logs"
+    }, {
+      href: "/logs/" + log.id,
+      text: "Log " + log.id
+    }, {
+      text: caption
+    }]
+  }) }}
+{% endblock %}
 
 {% block form %}
   <div class="govuk-grid-row">

--- a/app/views/logs/about-this-log/gdpr.njk
+++ b/app/views/logs/about-this-log/gdpr.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["yes-no"]

--- a/app/views/logs/about-this-log/letting-renewal.njk
+++ b/app/views/logs/about-this-log/letting-renewal.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["yes-no"]

--- a/app/views/logs/about-this-log/letting-start-date.njk
+++ b/app/views/logs/about-this-log/letting-start-date.njk
@@ -6,7 +6,7 @@
   {{ govukDateInput(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     hint: {

--- a/app/views/logs/about-this-log/organisation.njk
+++ b/app/views/logs/about-this-log/organisation.njk
@@ -3,7 +3,7 @@
 {% set title = "Organisation details" %}
 
 {% block question %}
-  {{ macro.heading(title, caption) }}
+  {{ macro.heading(title) }}
 
   {{ govukSelect(decorate({
     label: {

--- a/app/views/logs/about-this-log/purchaser-code.njk
+++ b/app/views/logs/about-this-log/purchaser-code.njk
@@ -6,7 +6,7 @@
   {{ govukInput(decorate({
     classes: "govuk-input--width-10",
     label: {
-      html: macro.heading(title, caption)
+      html: macro.heading(title)
     }
   }, ["logs", log.id, section.id, "purchaser-code"])) }}
 {% endblock %}

--- a/app/views/logs/about-this-log/sale-completion-date.njk
+++ b/app/views/logs/about-this-log/sale-completion-date.njk
@@ -6,7 +6,7 @@
   {{ govukDateInput(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     hint: {

--- a/app/views/logs/about-this-log/sale-or-letting.njk
+++ b/app/views/logs/about-this-log/sale-or-letting.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["sale-or-letting"]

--- a/app/views/logs/about-this-log/scheme.njk
+++ b/app/views/logs/about-this-log/scheme.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        html: macro.heading(title, caption)
+        html: macro.heading(title)
       }
     },
     items: data.questions.scheme | optionItems("name", "id", "hint")

--- a/app/views/logs/about-this-log/tenant-code.njk
+++ b/app/views/logs/about-this-log/tenant-code.njk
@@ -6,7 +6,7 @@
   {{ govukInput(decorate({
     classes: "govuk-input--width-10",
     label: {
-      html: macro.heading(title, caption)
+      html: macro.heading(title)
     }
   }, ["logs", log.id, section.id, "tenant-code"])) }}
 {% endblock %}

--- a/app/views/logs/about-this-log/type-of-need.njk
+++ b/app/views/logs/about-this-log/type-of-need.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        html: macro.heading(title, caption)
+        html: macro.heading(title)
       }
     },
     items: data.questions["type-of-need"]

--- a/app/views/logs/about-this-log/type-of-rent.njk
+++ b/app/views/logs/about-this-log/type-of-rent.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        html: macro.heading(title, caption)
+        html: macro.heading(title)
       }
     },
     items: data.questions["type-of-rent"]

--- a/app/views/logs/about-this-log/uses-scheme.njk
+++ b/app/views/logs/about-this-log/uses-scheme.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        html: macro.heading(title, caption)
+        html: macro.heading(title)
       }
     },
     items: data.questions["yes-no"]

--- a/app/views/logs/household-situation/previous-homelessness.njk
+++ b/app/views/logs/household-situation/previous-homelessness.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["homelessness"]

--- a/app/views/logs/household-situation/previous-housing-situation.njk
+++ b/app/views/logs/household-situation/previous-housing-situation.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["housing-situation"]

--- a/app/views/logs/household-situation/reason-for-leaving.njk
+++ b/app/views/logs/household-situation/reason-for-leaving.njk
@@ -3,7 +3,7 @@
 {% set title = "Leaving their last settled home" %}
 
 {% block question %}
-  {{ macro.heading(title, caption) }}
+  {{ macro.heading(title) }}
 
   {{ govukRadios(decorate({
     fieldset: {

--- a/app/views/logs/log.njk
+++ b/app/views/logs/log.njk
@@ -6,7 +6,7 @@
   {{ govukBreadcrumbs({
     items: [{
       href: "/logs",
-      text: "Logs"
+      text: "Case logs"
     }, {
       text: title
     }]
@@ -16,7 +16,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-      <h1 class="govuk-heading-xl govuk-!-width-two-thirds">{{ title }}</h1>
+      <h1 class="govuk-heading-xl">{{ title }}</h1>
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">This log is incomplete</h2>
       <p class="govuk-body govuk-!-margin-bottom-7">
         You have completed 0 of {{ data.sections | length }} sections.<br>

--- a/app/views/logs/property-information/is-adapted.njk
+++ b/app/views/logs/property-information/is-adapted.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["yes-no"]

--- a/app/views/logs/property-information/is-relet.njk
+++ b/app/views/logs/property-information/is-relet.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["re-let"]

--- a/app/views/logs/property-information/local-authority-known.njk
+++ b/app/views/logs/property-information/local-authority-known.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["yes-no"]

--- a/app/views/logs/property-information/local-authority.njk
+++ b/app/views/logs/property-information/local-authority.njk
@@ -5,7 +5,7 @@
 {% block question %}
   {{ rigAutocomplete(decorate({
     label: {
-      html: macro.heading(title, caption)
+      html: macro.heading(title)
     },
     items: data.questions["local-authorities"]
   }, ["logs", log.id, section.id, "local-authorities"])) }}

--- a/app/views/logs/property-information/number-of-bedrooms.njk
+++ b/app/views/logs/property-information/number-of-bedrooms.njk
@@ -6,7 +6,7 @@
   {{ govukInput(decorate({
     classes: "govuk-input--width-2",
     label: {
-      html: macro.heading(title, caption)
+      html: macro.heading(title)
     },
     inputmode: "numeric",
     pattern: "[0-9]*"

--- a/app/views/logs/property-information/postcode.njk
+++ b/app/views/logs/property-information/postcode.njk
@@ -15,7 +15,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: [{

--- a/app/views/logs/property-information/reason-for-vacancy-non-relet.njk
+++ b/app/views/logs/property-information/reason-for-vacancy-non-relet.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["reason-for-vacancy-non-relet"]

--- a/app/views/logs/property-information/reason-for-vacancy.njk
+++ b/app/views/logs/property-information/reason-for-vacancy.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["reason-for-vacancy"]

--- a/app/views/logs/property-information/reference.njk
+++ b/app/views/logs/property-information/reference.njk
@@ -7,7 +7,7 @@
   {{ govukInput(decorate({
     classes: "govuk-input--width-20",
     label: {
-      html: macro.heading(title, caption)
+      html: macro.heading(title)
     },
     hint: {
       text: hint

--- a/app/views/logs/property-information/repairs.njk
+++ b/app/views/logs/property-information/repairs.njk
@@ -16,10 +16,11 @@
     items: data.questions["date-full"]
   }, ["logs", log.id, section.id, "repairs-date"])) }}
   {% endset %}
+
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: [

--- a/app/views/logs/property-information/times-previously-offered.njk
+++ b/app/views/logs/property-information/times-previously-offered.njk
@@ -13,7 +13,7 @@
   {{ govukInput(decorate({
     classes: "govuk-input--width-2",
     label: {
-      html: macro.heading(title, caption)
+      html: macro.heading(title)
     },
     hint: {
       text: hint

--- a/app/views/logs/property-information/type-of-let.njk
+++ b/app/views/logs/property-information/type-of-let.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["type-of-let"]

--- a/app/views/logs/property-information/type-of-property.njk
+++ b/app/views/logs/property-information/type-of-property.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["type-of-property"]

--- a/app/views/logs/property-information/type-of-unit.njk
+++ b/app/views/logs/property-information/type-of-unit.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["type-of-unit"]

--- a/app/views/logs/property-information/void-date.njk
+++ b/app/views/logs/property-information/void-date.njk
@@ -11,7 +11,7 @@
   {{ govukDateInput(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     hint: {

--- a/app/views/logs/property-information/why-dont-you-know-postcode-or-la.njk
+++ b/app/views/logs/property-information/why-dont-you-know-postcode-or-la.njk
@@ -5,7 +5,7 @@
 {% block question %}
   {{ govukTextarea(decorate({
     label: {
-      text: macro.heading(title, caption)
+      text: macro.heading(title)
     }
   }, ["logs", log.id, section.id, "why-dont-you-know-postcode-or-la"])) }}
 {% endblock %}

--- a/app/views/logs/tenancy-information/is-starter.njk
+++ b/app/views/logs/tenancy-information/is-starter.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["yes-no"]

--- a/app/views/logs/tenancy-information/start-date.njk
+++ b/app/views/logs/tenancy-information/start-date.njk
@@ -6,7 +6,7 @@
   {{ govukDateInput(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     hint: {

--- a/app/views/logs/tenancy-information/type-of-tenancy.njk
+++ b/app/views/logs/tenancy-information/type-of-tenancy.njk
@@ -6,7 +6,7 @@
   {{ govukRadios(decorate({
     fieldset: {
       legend: {
-        text: macro.heading(title, caption)
+        text: macro.heading(title)
       }
     },
     items: data.questions["type-of-tenancy"]


### PR DESCRIPTION
Use breadcrumbs consistently throughout a case log:

`Case logs > Log [LOG_ID] > [SECTION_NAME]`

Moving the section name into the breadcrumb also frees up the caption which can be used for adding additional content to questions.

<img width="700" alt="Screenshot 2021-12-01 at 14 39 09" src="https://user-images.githubusercontent.com/813383/144254469-dc99ac9c-7c36-422f-8a55-a30071842ea2.png">
<img width="480" alt="Screenshot 2021-12-01 at 14 38 59" src="https://user-images.githubusercontent.com/813383/144254508-e03cbf31-41e4-4b3c-8acd-2bd7bfc2b306.png">
