### PR TITLE
Fix missing missing answer text

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -22,7 +22,8 @@ export default (env) => {
 
     const noValueProvidedText = safe('<span class="app-!-colour-muted">You didn’t answer this question</span>')
 
-    if (!value) {
+    // Nunjucks sometimes returns an object with an empty value
+    if (!value || value.val === '') {
       return noValueProvidedText
     }
 
@@ -51,7 +52,7 @@ export default (env) => {
     // (We’ll assume only dates are objects, for now)
     if (typeof value === 'object' && !Array.isArray(value)) {
       const date = govukDate(isoDateFromDateInput(value))
-      return date !== 'Invalid Date' ? date : noValueProvidedText
+      return date !== 'Invalid DateTime' ? date : noValueProvidedText
     }
 
     return value


### PR DESCRIPTION
Urgh. Text provided by a Nunjucks macro gets reformatted as an object:

```
{
  val: '',
  length: 0
}
```

So we need to test for this being passed back to the `textFromInputValue` filter in order to return the `You didn’t answer this question` text.

<img width="733" alt="Screenshot 2021-12-08 at 15 23 25" src="https://user-images.githubusercontent.com/813383/145234672-0dcb8486-5123-4219-96dc-9ccf72965df4.png">
