### PR TITLE
added a couple of quick dirty fixes

### DIFF
--- a/app/globals.js
+++ b/app/globals.js
@@ -50,7 +50,9 @@ export default () => {
       }
     }
 
-    return incompleteSections[0]
+    console.log(incompleteSections)
+
+    return incompleteSections[1]
   }
 
   globals.taskListSections = function (logId) {

--- a/app/views/logs/log.njk
+++ b/app/views/logs/log.njk
@@ -20,7 +20,7 @@
       <h2 class="govuk-heading-s govuk-!-margin-bottom-2">This log is incomplete</h2>
       <p class="govuk-body govuk-!-margin-bottom-7">
         You have completed 0 of {{ data.sections | length }} sections.<br>
-        Skip to next incomplete section: <a href="#{{ nextSection(log.id).id }}">{{ nextSection(log.id).title }}</a>
+        <a href="#{{ nextSection(log.id).id }}" class="govuk-skip-link">Skip to next incomplete section: {{ nextSection(log.id).title }}</a>
       </p>
 
       {{ rigTaskList({


### PR DESCRIPTION
Two fixes that need revisiting:

* Add the `govuk-skip-link` class to the "skip to next incomplete section" link on the task list
* The button "Save and go to next incomplete section" is currently going to the current section. To fix this I made `globals. nextSection` return the second element in the array of incomplete sections, rather than the first. This is beyond filth. 

More generally, this prototype is horribly complex and is giving me "the fear". 