### PR TITLE
CLDC-790 Add supported housing questions to Finances section

### DIFF
--- a/app/data/sections.js
+++ b/app/data/sections.js
@@ -302,6 +302,53 @@ export function sections (log) {
     }]
   }
 
+  const financesSupportedHousing = {
+    id: 'finances-supported-housing',
+    title: 'Income, benefits and outgoings',
+    group: 'finances',
+    paths: getPaths('finances-supported-housing', [
+      'income-period',
+      'income-value',
+      'income-benefits',
+      'income-benefits-portion',
+      'outgoings-includes-rent',
+      'outgoings-period',
+      'outgoings-includes-care-home',
+      'outgoings-value',
+      'check-your-answers'
+    ]),
+    forks: (sectionPath, keyPathRoot) => [{
+      currentPath: `${sectionPath}/outgoings-includes-rent`,
+      forkPath: `${sectionPath}/check-your-answers`,
+      storedData: keyPathRoot.concat('outgoings-includes-rent'),
+      values: ['false']
+    }, {
+      currentPath: `${sectionPath}/outgoings-includes-care-home`,
+      forkPath: `${sectionPath}/outgoings-after-benefits`,
+      storedData: keyPathRoot.concat('income-benefits'),
+      excludedValues: ['none', 'unknown', 'prefers-not-to-say']
+    }, {
+      currentPath: `${sectionPath}/outgoings-value`,
+      forkPath: `${sectionPath}/outgoings-after-benefits`,
+      storedData: keyPathRoot.concat('income-benefits'),
+      excludedValues: ['none', 'unknown', 'prefers-not-to-say']
+    }, {
+      currentPath: `${sectionPath}/outgoings-after-benefits`,
+      forkPath: (value) => {
+        if (value === 'true') {
+          return `${sectionPath}/outgoings-outstanding`
+        } else {
+          return `${sectionPath}/check-your-answers`
+        }
+      },
+      storedData: keyPathRoot.concat('outgoings-after-benefits'),
+      values: ['true', 'false']
+    }, {
+      currentPath: `${sectionPath}/outgoings-outstanding`,
+      skipTo: `${sectionPath}/check-your-answers`
+    }]
+  }
+
   /**
    * Declaration
    */
@@ -329,7 +376,8 @@ export function sections (log) {
     ...(!isSupportedHousing && !isRenewal ? [propertyInformation] : []),
     ...(!isSupportedHousing && isRenewal ? [propertyInformationRenewal] : []),
     ...(isSupportedHousing && !isRenewal ? [propertyInformationSupportedHousing] : []),
-    finances,
+    ...(!isSupportedHousing ? [finances] : []),
+    ...(isSupportedHousing ? [financesSupportedHousing] : []),
     declaration
   ]
 }

--- a/app/routes/logs.js
+++ b/app/routes/logs.js
@@ -91,14 +91,17 @@ export const logRoutes = (router) => {
         view = itemId
       }
 
-      // Property and tenancy information sections have variants that share
-      // the same views
+      // Property, tenancy information and finance sections have variants
+      // that share the same views
       let sectionViewsDir = sectionId
       if (sectionId.startsWith('property-information')) {
         sectionViewsDir = 'property-information'
       }
       if (sectionId.startsWith('tenancy-information')) {
         sectionViewsDir = 'tenancy-information'
+      }
+      if (sectionId.startsWith('finances')) {
+        sectionViewsDir = 'finances'
       }
 
       const log = utils.getEntityById(logs, logId)

--- a/app/views/logs/finances/check-your-answers.njk
+++ b/app/views/logs/finances/check-your-answers.njk
@@ -1,13 +1,15 @@
 {% extends "layouts/check-answers.njk" %}
 
-{% from "components/summary-message/macro.njk" import appSummaryMessage %}
-
 {% set period = log[section.id]["income-period"] | replace("ly", "") %}
 {% set hasIncomeBenefits =
   (log[section.id]["income-benefits"] !== "none") and
   (log[section.id]["income-benefits"] !== "unknown") and
   (log[section.id]["income-benefits"] !== "prefers-not-to-say")
 %}
+{% set hasOutgoingsAfterBenefits = log[section.id]["outgoings-after-benefits"] == "true" %}
+{% set isSupported = log["about-this-log"]["type-of-need"] == "supported" %}
+{% set isRenter = log[section.id]["outgoings-includes-rent"] == "true" | string %}
+{% set isCareHome = log[section.id]["outgoings-includes-care-home"] == "true" | string %}
 
 {% block checkAnswers %}
   {{ govukSummaryList({
@@ -57,42 +59,71 @@
       }) if not isCompleted
     }, {
       key: {
-        text: "Frequency of household rent and charges"
+        text: "Does the household pay rent or charges?"
+      },
+      value: {
+        text: log[section.id]["outgoings-includes-rent"] | textFromInputValue(data.questions["yes-no"])
+      },
+      actions: actionLinks({
+        href: sectionPath + "/outgoings-includes-rent",
+        visuallyHiddenText: "if the household pay rent or charges"
+      }) if not isCompleted
+    } if isSupported, {
+      key: {
+        text: "Frequency of household rent or charges"
       },
       value: {
         text: log[section.id]["outgoings-period"] | textFromInputValue(data.questions["outgoings-period"])
       },
       actions: actionLinks({
         href: sectionPath + "/outgoings-period",
-        visuallyHiddenText: "frequency of household rent and charges"
+        visuallyHiddenText: "frequency of household rent or charges"
       }) if not isCompleted
-    }, {
+    } if isRenter, {
       key: {
-        text: "Total household rent and charges"
+        text: "Care home accomodation"
       },
       value: {
-        html: appSummaryMessage ({
-          classes: "app-summary-message--information",
-          titleText: "Value is outside the expected range. You should check this is correct before submitting.",
-          text: log[section.id]["outgoings-value"] | sterling
-        })
+        text: log[section.id]["outgoings-includes-care-home"] | textFromInputValue(data.questions["yes-no"])
+      },
+      actions: actionLinks({
+        href: sectionPath + "/outgoings-includes-care-home",
+        visuallyHiddenText: "if care home accommodation"
+      }) if not isCompleted
+    } if isSupported and isRenter, {
+      key: {
+        text: "Care home charges"
+      },
+      value: {
+        text: log[section.id]["outgoings-care-home"] | sterling
+      },
+      actions: actionLinks({
+        href: sectionPath + "/outgoings-includes-care-home",
+        visuallyHiddenText: "care home charges"
+      }) if not isCompleted
+    } if isCareHome and isRenter, {
+      key: {
+        text: "Total household rent or charges"
+      },
+      value: {
+        text: log[section.id]["outgoings-value"] | sterling
       },
       actions: actionLinks({
         href: sectionPath + "/outgoings-value",
-        visuallyHiddenText: "total household rent and charges"
+        visuallyHiddenText: "total household rent or charges"
       }) if not isCompleted
-    }, {
+    } if isRenter and not isCareHome, {
       key: {
-        text: "Outstanding amount for basic rent and charges"
+        text: "Will there be an outstanding amount for basic rent and eligible charges?"
       },
       value: {
         text: log[section.id]["outgoings-after-benefits"] | textFromInputValue(data.questions["yes-no"])
       },
       actions: actionLinks({
         href: sectionPath + "/outgoings-after-benefits",
-        visuallyHiddenText: "outstanding amount for basic rent and charges"
+        visuallyHiddenText: "if there will be an outstanding amount for basic rent and eligible charges"
       }) if not isCompleted
-    } if hasIncomeBenefits, {
+    } if isRenter and hasIncomeBenefits, {
       key: {
         text: "Estimated outstanding amount"
       },
@@ -103,6 +134,6 @@
         href: sectionPath + "/outgoings-outstanding",
         visuallyHiddenText: "estimated outstanding amount"
       }) if not isCompleted
-    } if hasIncomeBenefits and log[section.id]["outgoings-after-benefits"] == "true"]
+    } if isRenter and hasIncomeBenefits and hasOutgoingsAfterBenefits]
   }) }}
 {% endblock %}

--- a/app/views/logs/finances/outgoings-includes-care-home.njk
+++ b/app/views/logs/finances/outgoings-includes-care-home.njk
@@ -1,0 +1,46 @@
+{% extends "layouts/question.njk" %}
+
+{% set outgoingsPeriod = log[section.id]["outgoings-period"] %}
+ {% if outgoingsPeriod == "fortnightly" %}
+   {% set period = "every 2 weeks" %}
+ {% elif outgoingsPeriod == "every-4-weeks" %}
+   {% set period = "every 4 weeks" %}
+ {% elif outgoingsPeriod == "monthly" %}
+   {% set period = "per month" %}
+ {% else %}
+   {% set period = "per week" %}
+ {% endif %}
+{% set title = "Is this accommodation a care home?" %}
+
+{% block question %}
+  {{ govukRadios(decorate({
+    fieldset: {
+      legend: {
+        html: macro.heading(title, caption)
+      }
+    },
+    items: [{
+      value: "true",
+      text: "Yes",
+      conditional: {
+        html: govukInput(decorate({
+          classes: "govuk-input--width-5",
+          label: {
+            text: "How much does the household pay each " + period + "?"
+          },
+          inputmode: "numeric",
+          pattern: "[0-9]*",
+          prefix: {
+            text: "£"
+          },
+          suffix: {
+            text: period
+          }
+        }, ["logs", log.id, section.id, "outgoings-care-home"]))
+      }
+    }, {
+      value: "false",
+      text: "No"
+    }]
+  }, ["logs", log.id, section.id, "outgoings-includes-care-home"])) }}
+{% endblock %}

--- a/app/views/logs/finances/outgoings-includes-rent.njk
+++ b/app/views/logs/finances/outgoings-includes-rent.njk
@@ -1,0 +1,14 @@
+{% extends "layouts/question.njk" %}
+
+{% set title = "Does the household pay rent or charges for the accommodation?" %}
+
+{% block question %}
+  {{ govukRadios(decorate({
+    fieldset: {
+      legend: {
+        html: macro.heading(title, caption)
+      }
+    },
+    items: data.questions["yes-no"]
+  }, ["logs", log.id, section.id, "outgoings-includes-rent"])) }}
+{% endblock %}


### PR DESCRIPTION
As mapped, though not sure the question ‘After the household has received any housing-related benefits, will there be an outstanding amount for basic rent and eligible charges?’ should be shown if the answer to ‘Does the household pay rent or charges for the accommodation?‘ is ‘No’. But that’s what the map says, so that’s what the prototype does.