### PR TITLE
CLDC-788 Add interruption question to check rent value

### DIFF
--- a/app/components/_all.scss
+++ b/app/components/_all.scss
@@ -1,3 +1,5 @@
+@import "button/button";
 @import "output/output";
+@import "panel/panel";
 @import "sub-navigation/sub-navigation";
 @import "summary-message/summary-message";

--- a/app/components/button/_button.scss
+++ b/app/components/button/_button.scss
@@ -1,0 +1,31 @@
+$app-button-shadow-size: $govuk-border-width-form-element;
+$app-button-inverse-background-colour: govuk-colour("white");
+$app-button-inverse-foreground-colour: $govuk-brand-colour;
+$app-button-inverse-shadow-colour: govuk-shade($app-button-inverse-foreground-colour, 30%);
+$app-button-inverse-hover-background-colour: govuk-tint($app-button-inverse-foreground-colour, 90%);
+
+.app-button--inverse,
+.app-button--inverse:link,
+.app-button--inverse:visited {
+  color: $app-button-inverse-foreground-colour;
+  background-color: $app-button-inverse-background-colour;
+  box-shadow: 0 $app-button-shadow-size 0 $app-button-inverse-shadow-colour;
+}
+
+.app-button--inverse:hover {
+  color: $app-button-inverse-foreground-colour;
+  background-color: $app-button-inverse-hover-background-colour;
+}
+
+.app-button--inverse:focus:not(:hover) {
+  color: $govuk-focus-text-colour;
+  background-color: $govuk-focus-colour;
+}
+
+.app-button--inverse:active,
+.app-button--inverse:focus {
+  border-color: $govuk-focus-colour;
+  color: $app-button-inverse-foreground-colour;
+  background-color: $app-button-inverse-hover-background-colour;
+  box-shadow: inset 0 0 0 2px $govuk-focus-colour;
+}

--- a/app/components/panel/_panel.scss
+++ b/app/components/panel/_panel.scss
@@ -1,0 +1,34 @@
+.app-panel--informational {
+  background-color: govuk-colour("blue");
+  color: govuk-colour("white");
+  text-align: left;
+
+  .app-panel__body {
+    @include govuk-font($size: 19);
+    margin: 0;
+  }
+}
+
+.app-panel--interruption {
+  background-color: govuk-colour("blue");
+  color: govuk-colour("white");
+  text-align: left;
+
+  .govuk-body,
+  .govuk-label,
+  .govuk-fieldset__legend,
+  .govuk-hint {
+    color: govuk-colour("white");
+  }
+
+  *:last-child {
+    margin-bottom: 0;
+  }
+
+  .govuk-radios__label::before,
+  & ::after {
+    color: govuk-colour("black");
+    border-color: govuk-colour("black");
+    background-color: govuk-colour("white");
+  }
+}

--- a/app/data/sections.js
+++ b/app/data/sections.js
@@ -280,10 +280,16 @@ export function sections (log) {
       'income-benefits-portion',
       'outgoings-period',
       'outgoings-value',
+      'outgoings-value-check',
       'check-your-answers'
     ]),
     forks: (sectionPath, keyPathRoot) => [{
-      currentPath: `${sectionPath}/outgoings-value`,
+      currentPath: `${sectionPath}/income-period`,
+      forkPath: `${sectionPath}/income-benefits`,
+      storedData: keyPathRoot.concat('income-period'),
+      values: ['prefers-not-to-say']
+    }, {
+      currentPath: `${sectionPath}/outgoings-value-check`,
       forkPath: `${sectionPath}/outgoings-after-benefits`,
       storedData: keyPathRoot.concat('income-benefits'),
       excludedValues: ['none', 'unknown', 'prefers-not-to-say']
@@ -317,9 +323,15 @@ export function sections (log) {
       'outgoings-period',
       'outgoings-includes-care-home',
       'outgoings-value',
+      'outgoings-value-check',
       'check-your-answers'
     ]),
     forks: (sectionPath, keyPathRoot, req) => [{
+      currentPath: `${sectionPath}/income-period`,
+      forkPath: `${sectionPath}/income-benefits`,
+      storedData: keyPathRoot.concat('income-period'),
+      values: ['prefers-not-to-say']
+    }, {
       currentPath: `${sectionPath}/outgoings-includes-rent`,
       forkPath: `${sectionPath}/check-your-answers`,
       storedData: keyPathRoot.concat('outgoings-includes-rent'),
@@ -344,7 +356,7 @@ export function sections (log) {
       storedData: keyPathRoot.concat('outgoings-includes-care-home'),
       values: ['true', 'false']
     }, {
-      currentPath: `${sectionPath}/outgoings-value`,
+      currentPath: `${sectionPath}/outgoings-value-check`,
       forkPath: `${sectionPath}/outgoings-after-benefits`,
       storedData: keyPathRoot.concat('income-benefits'),
       excludedValues: ['none', 'unknown', 'prefers-not-to-say']

--- a/app/layouts/question-interruption.njk
+++ b/app/layouts/question-interruption.njk
@@ -1,0 +1,38 @@
+{% extends "layouts/form.njk" %}
+
+{% set hasAnsweredQuestion =
+  log[section.id][itemId][questionId] or
+  log[section.id][questionId] %}
+
+{% set backLink = 'javascript:history.go(-1);' %}
+
+{% if questionId and hasAnsweredQuestion %}
+  {% set formAction = formAction or sectionPath + "/check-your-answers" %}
+  {% set buttonText = buttonText or "Save changes" %}
+{% else %}
+  {% set formAction = formAction or paths.current %}
+  {% set buttonText = buttonText or "Save and continue" %}
+{% endif %}
+
+{% block form %}
+  {{ govukErrorSummary({
+    titleText: "There is a problem",
+    errorList: errorList(errors)
+  }) if errors }}
+
+  <div class="govuk-panel app-panel--interruption">
+    <h1 class="govuk-panel__title">
+      {{ title | noOrphans | safe }}
+    </h1>
+
+    <div class="govuk-panel__body">
+      {% block interruption %}
+      {% endblock %}
+
+      {{ govukButton({
+        classes: "app-button--inverse",
+        text: buttonText
+      }) }}
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/logs/finances/check-your-answers.njk
+++ b/app/views/logs/finances/check-your-answers.njk
@@ -84,28 +84,6 @@
         text: "Care home accomodation"
       },
       value: {
-        text: log[section.id]["outgoings-includes-care-home"] | textFromInputValue(data.questions["yes-no"])
-      },
-      actions: actionLinks({
-        href: sectionPath + "/outgoings-includes-care-home",
-        visuallyHiddenText: "if care home accommodation"
-      }) if not isCompleted
-    } if isSupported and isRenter, {
-      key: {
-        text: "Care home charges"
-      },
-      value: {
-        text: log[section.id]["outgoings-care-home"] | sterling
-      },
-      actions: actionLinks({
-        href: sectionPath + "/outgoings-includes-care-home",
-        visuallyHiddenText: "care home charges"
-      }) if not isCompleted
-    } if isCareHome and isRenter, {
-      key: {
-        text: "Total household rent or charges"
-      },
-      value: {
         text: log[section.id]["outgoings-value"] | sterling
       },
       actions: actionLinks({

--- a/app/views/logs/finances/outgoings-value-check.njk
+++ b/app/views/logs/finances/outgoings-value-check.njk
@@ -1,0 +1,28 @@
+{% extends "layouts/question-interruption.njk" %}
+
+{% set outgoingsPeriod = log[section.id]["outgoings-period"] %}
+{% if outgoingsPeriod == "fortnightly" %}
+  {% set period = "every 2 weeks" %}
+{% elif outgoingsPeriod == "every-4-weeks" %}
+  {% set period = "every 4 weeks" %}
+{% elif outgoingsPeriod == "monthly" %}
+  {% set period = "per month" %}
+{% else %}
+  {% set period = "per week" %}
+{% endif %}
+{% set title = "Value for rent is outside of the expected range" %}
+{% set questionId = "outgoings-value-correct" %}
+
+{% block interruption %}
+  <p class="govuk-body">The maximum rent for a property in the South East is £150 {{ period }}.</p>
+  <p class="govuk-body">You entered <strong>{{ log[section.id]["outgoings-rent"] | sterling }} {{ period }}</strong></p>
+  {{ govukRadios(decorate({
+    fieldset: {
+      legend: {
+        classes: "govuk-fieldset__legend--m",
+        text: "Is this value correct?"
+      }
+    },
+    items: data.questions["yes-no"]
+  }, ["logs", log.id, section.id, questionId])) }}
+{% endblock %}


### PR DESCRIPTION
Adds an interruption screen after entering rents and charges.

This screen should only appear if a figure outside the expected range is entered, but for the purposes of the prototype, it will always be shown. Selecting ‘No’ should take you back to the previous question, but for now, regardless of the answer, the user is always taken to the next question. We can decide if we want to make this work properly, prior to testing.

![soft-validation](https://user-images.githubusercontent.com/813383/146832257-eb83893a-834a-4b92-b589-0950ad6680bf.png)
