### PR TITLE
CLDC-916 - Remove answer numbers

### DIFF
--- a/app/data/questions/income-benefits-portion.js
+++ b/app/data/questions/income-benefits-portion.js
@@ -1,19 +1,15 @@
 export default [{
-  text: '1. All',
-  answer: 'All',
+  text: 'All',
   value: 'all'
 }, {
-  text: '2. Some',
-  answer: 'Some',
+  text: 'Some',
   value: 'some'
 }, {
-  text: '3. None',
-  answer: 'None',
+  text: 'None',
   value: 'none'
 }, {
   divider: 'or'
 }, {
-  text: '4. Don’t know',
-  answer: 'Don’t know',
+  text: 'Don’t know',
   value: 'unknown'
 }]

--- a/app/data/questions/nationality.js
+++ b/app/data/questions/nationality.js
@@ -1,71 +1,54 @@
 export default [{
-  text: '1. UK national resident in UK',
-  answer: 'UK national resident in UK',
+  text: 'UK national resident in UK',
   value: '1'
 }, {
-  text: '2. UK national returning from residence overseas',
-  answer: 'UK national returning from residence overseas',
+  text: 'UK national returning from residence overseas',
   value: '2'
 }, {
-  text: '14. Bulgarian',
-  answer: 'Bulgarian',
+  text: 'Bulgarian',
   value: '14'
 }, {
-  text: '16. Croatian',
-  answer: 'Croatian',
+  text: 'Croatian',
   value: '16'
 }, {
-  text: '3. Czech',
-  answer: 'Czech',
+  text: 'Czech',
   value: '3'
 }, {
-  text: '4. Estonian',
-  answer: 'Estonian',
+  text: 'Estonian',
   value: '4'
 }, {
-  text: '5. Hungarian',
-  answer: 'Hungarian',
+  text: 'Hungarian',
   value: '5'
 }, {
-  text: '17. Irish',
-  answer: 'Irish',
+  text: 'Irish',
   value: '17'
 }, {
-  text: '6. Latvian',
-  answer: 'Latvian',
+  text: 'Latvian',
   value: '6'
 }, {
-  text: '7. Lithuanian',
-  answer: 'Lithuanian',
+  text: 'Lithuanian',
   value: '7'
 }, {
-  text: '8. Polish',
-  answer: 'Polish',
+  text: 'Polish',
   value: '8'
 }, {
-  text: '15. Romanian',
-  answer: 'Romanian',
+  text: 'Romanian',
   value: '15'
 }, {
-  text: '9. Slovakian',
-  answer: 'Slovakian',
+  text: 'Slovakian',
   value: '9'
 }, {
-  text: '10. Slovenian',
-  answer: 'Slovenian',
+  text: 'Slovenian',
   value: '10'
 }, {
-  text: '11. From another European Economic Area (EEA) country',
-  answer: 'From another European Economic Area (EEA) country',
+  text: 'From another European Economic Area (EEA) country',
   value: '11'
 }, {
   divider: 'or'
 }, {
-  text: '12. From any other country',
-  answer: 'From any other country',
+  text: 'From any other country',
   value: '12'
 }, {
-  text: '13. Tenant prefers not to say',
-  answer: 'Tenant prefers not to say',
+  text: 'Tenant prefers not to say',
   value: '13'
 }]

--- a/app/data/questions/outgoings-period.js
+++ b/app/data/questions/outgoings-period.js
@@ -1,37 +1,28 @@
 export default [{
-  text: '1. Weekly for 52 weeks',
-  answer: 'Weekly for 52 weeks',
+  text: 'Weekly for 52 weeks',
   value: 'weekly-52'
 }, {
-  text: '2. Every 2 weeks',
-  answer: 'Every 2 weeks',
+  text: 'Every 2 weeks',
   value: 'fortnightly'
 }, {
-  text: '3. Every 4 weeks',
-  answer: 'Every 4 weeks',
+  text: 'Every 4 weeks',
   value: 'every-4-weeks'
 }, {
-  text: '4. Every calendar month',
-  answer: 'Every calendar month',
+  text: 'Every calendar month',
   value: 'monthly'
 }, {
-  text: '5. Weekly for 50 weeks',
-  answer: 'Weekly for 50 weeks',
+  text: 'Weekly for 50 weeks',
   value: 'weekly-50'
 }, {
-  text: '6. Weekly for 49 weeks',
-  answer: 'Weekly for 49 weeks',
+  text: 'Weekly for 49 weeks',
   value: 'weekly-49'
 }, {
-  text: '7. Weekly for 48 weeks',
-  answer: 'Weekly for 48 weeks',
+  text: 'Weekly for 48 weeks',
   value: 'weekly-48'
 }, {
-  text: '8. Weekly for 47 weeks',
-  answer: 'Weekly for 47 weeks',
+  text: 'Weekly for 47 weeks',
   value: 'weekly-47'
 }, {
-  text: '9. Weekly for 46 weeks',
-  answer: 'Weekly for 46 weeks',
+  text: 'Weekly for 46 weeks',
   value: 'weekly-46'
 }]

--- a/app/data/questions/relationship-to-lead-tenant.js
+++ b/app/data/questions/relationship-to-lead-tenant.js
@@ -1,19 +1,15 @@
 export default [{
-  text: '1. Partner',
-  answer: 'Partner',
+  text: 'Partner',
   value: '1'
 }, {
-  text: '2. Child',
-  answer: 'Child',
+  text: 'Child',
   value: '2'
 }, {
-  text: '3. Other',
-  answer: 'Other',
+  text: 'Other',
   value: '3'
 }, {
   divider: 'or'
 }, {
-  text: '4. Tenant prefers not to say',
-  answer: 'Tenant prefers not to say',
+  text: 'Tenant prefers not to say',
   value: 'prefer-not-to-say'
 }]

--- a/app/data/questions/sheltered-accommodation.js
+++ b/app/data/questions/sheltered-accommodation.js
@@ -1,19 +1,15 @@
 export default [{
-  text: '1. Yes – Sheltered housing',
-  answer: 'Sheltered housing',
+  text: 'Sheltered housing',
   value: 'sheltered'
 }, {
-  text: '2. Yes – Extra care housing',
-  answer: 'Extra care housing',
+  text: 'Extra care housing',
   value: 'fortnightly'
 }, {
-  text: '3. No',
-  answer: 'No',
+  text: 'No',
   value: 'false'
 }, {
   divider: 'or'
 }, {
-  text: '4. Don’t know',
-  answer: 'Don’t know',
+  text: 'Don’t know',
   value: 'unknown'
 }]

--- a/app/data/questions/type-of-benefit.js
+++ b/app/data/questions/type-of-benefit.js
@@ -1,31 +1,24 @@
 export default [{
-  text: '1. Housing benefit',
-  answer: 'Housing benefit',
+  text: 'Housing benefit',
   value: 'housing-benefit'
 }, {
-  text: '6. Universal Credit with housing element (excluding housing benefit)',
-  answer: 'Universal Credit with housing element (excluding housing benefit)',
+  text: 'Universal Credit with housing element (excluding housing benefit)',
   value: 'uc-plus-housing-element'
 }, {
-  text: '7. Universal Credit (without housing element)',
-  answer: 'Universal Credit (without housing element)',
+  text: 'Universal Credit (without housing element)',
   value: 'uc'
 }, {
-  text: '8. Housing benefit and Universal Credit (without housing element)',
-  answer: 'Housing benefit and Universal Credit (without housing element)',
+  text: 'Housing benefit and Universal Credit (without housing element)',
   value: 'uc-plus-housing-benefit'
 }, {
-  text: '9. None',
-  answer: 'None',
+  text: 'None',
   value: 'none'
 }, {
   divider: 'or'
 }, {
-  text: '3. Don’t know',
-  answer: 'Don’t know',
+  text: 'Don’t know',
   value: 'unknown'
 }, {
-  text: '10. Tenant prefers not to say',
-  answer: 'Tenant prefers not to say',
+  text: 'Tenant prefers not to say',
   value: 'prefers-not-to-say'
 }]

--- a/app/data/questions/type-of-registered-home.js
+++ b/app/data/questions/type-of-registered-home.js
@@ -1,11 +1,11 @@
 export default [{
-  text: 'Yes – registered care home providing nursing care',
+  text: 'Yes – registered care home providing nursing care',
   value: 'nursing'
 }, {
-  text: 'Yes – registered care home providing personal care',
+  text: 'Yes – registered care home providing personal care',
   value: 'personal'
 }, {
-  text: 'Yes – part registered care home',
+  text: 'Yes – part registered care home',
   value: 'part-registered'
 }, {
   text: 'No',

--- a/app/data/questions/type-of-tenancy.js
+++ b/app/data/questions/type-of-tenancy.js
@@ -1,25 +1,19 @@
 export default [{
-  text: '6. Fixed term – Secure',
-  answer: 'Fixed term – Secure',
+  text: 'Fixed term – Secure',
   value: 'fixed-secure'
 }, {
-  text: '1. Fixed term – Assured Shorthold Tenancy (AST)',
-  answer: 'Fixed term – Assured Shorthold Tenancy (AST)',
+  text: 'Fixed term – Assured Shorthold Tenancy (AST)',
   value: 'fixed-ast'
 }, {
-  text: '7. Lifetime – Secure',
-  answer: 'Lifetime – Secure',
+  text: 'Lifetime – Secure',
   value: 'lifetime-secure'
 }, {
-  text: '2. Lifetime – Assured',
-  answer: 'Lifetime – Assured',
+  text: 'Lifetime – Assured',
   value: 'lifetime-assured'
 }, {
-  text: '6. License agreement',
-  answer: 'License agreement',
+  text: 'License agreement',
   value: 'license'
 }, {
-  text: '3. Other',
-  answer: 'Other',
+  text: 'Other',
   value: 'other'
 }]

--- a/app/data/questions/working-situation.js
+++ b/app/data/questions/working-situation.js
@@ -1,47 +1,36 @@
 export default [{
-  text: '1. Full-time – 30 hours or more',
-  answer: 'Full-time – 30 hours or more',
+  text: 'Full-time – 30 hours or more',
   value: '1'
 }, {
-  text: '2. Part-time – Less than 30 hours a week',
-  answer: 'Part-time – Less than 30 hours a week',
+  text: 'Part-time – Less than 30 hours a week',
   value: '2'
 }, {
-  text: '3. In government training into work, such as New Deal',
-  answer: 'In government training into work, such as New Deal',
+  text: 'In government training into work, such as New Deal',
   value: '3'
 }, {
-  text: '4. Jobseeker',
-  answer: 'Jobseeker',
+  text: 'Jobseeker',
   value: '4'
 }, {
-  text: '5. Retired',
-  answer: 'Retired',
+  text: 'Retired',
   value: '5'
 }, {
-  text: '6. Not seeking work',
-  answer: 'Not seeking work',
+  text: 'Not seeking work',
   value: '6'
 }, {
-  text: '7. Full-time student',
-  answer: 'Full-time student',
+  text: 'Full-time student',
   value: '7'
 }, {
-  text: '8. Unable to work because of long-term sickness or disability',
-  answer: 'Unable to work because of long-term sickness or disability',
+  text: 'Unable to work because of long-term sickness or disability',
   value: '8'
 }, {
-  text: '9. Child under 16',
-  answer: 'Child under 16',
+  text: 'Child under 16',
   value: '9'
 }, {
   divider: 'or'
 }, {
-  text: '0. Other',
-  answer: 'Other',
+  text: 'Other',
   value: '0'
 }, {
-  text: '10. Tenant prefers not to say',
-  answer: 'Tenant prefers not to say',
+  text: 'Tenant prefers not to say',
   value: '10'
 }]


### PR DESCRIPTION
We currently don't need these as we've decided to defer any decision around adding numbers to the question options until we've redesigned the paper form.